### PR TITLE
Make html template valid HTML

### DIFF
--- a/page.template.html
+++ b/page.template.html
@@ -1,8 +1,18 @@
-<html><body>
-    
-    <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
-      <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
-    <br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-
-  </body>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Project Title</title>
+</head>
+<body>
+    <p>
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+            <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" />
+        </a>
+        <br />
+        This work is licensed under a
+        <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+            Creative Commons Attribution-ShareAlike 4.0 International License
+        </a>.
+    </p>
+</body>
 </html>


### PR DESCRIPTION
The template for the HTML page was invalid, which can be checked with https://validator.w3.org/. This patch adds a DOCTYPE and a the required <title>-tag. It also tries to make the HTML easier to read by rearanging it.